### PR TITLE
Don't use specialized scripts, make the module runnable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.pyc
+*~
 /dist/
 /node_modules/
 /clients/vscode/out/

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Running the server
 
 - Install the dependencies via :command:`poetry install`
 - Launch the server in tcp mode (binds to ``127.0.0.1:2087`` by default) via
-  :command:`poetry run server --tcp`
+  :command:`python3 -mrpm_spec_language_server --tcp`
 
 
 Clients
@@ -34,3 +34,18 @@ requires nodejs and the :command:`npm` package manager:
 
 Install the created :file:`rpm-spec-language-server-$VERSION.vsix` and launch
 the language server in tcp mode.
+
+vis with [vis-lspci](https://gitlab.com/muhq/vis-lspc)
+------------------------------------------------------
+
+Add to your `~/.config/vis/visrc.lua` this code:
+
+.. code-block:: lua
+
+    lsp = require('plugins/vis-lspc')
+    lsp.logging = true
+    lsp.highlight_diagnostics = true
+    lsp.ls_map['rpmspec'] = {
+        name = 'RPMSpec',
+        cmd = 'python3 -mrpm_spec_language_server --tcp'
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ mypy = ">=1.3"
 Sphinx = ">=7"
 
 [tool.poetry.scripts]
-server = "rpm_spec_language_server.main:main"
+rpm_lsp_server = "rpm_spec_language_server.main:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/rpm_spec_language_server/__main__.py
+++ b/rpm_spec_language_server/__main__.py
@@ -1,5 +1,8 @@
+import logging
 from rpm_spec_language_server.server import create_rpm_lang_server
 
+logging.basicConfig(format='%(levelname)s:%(funcName)s:%(message)s',
+                    level=logging.DEBUG)
 
 def main() -> None:
     import argparse
@@ -21,3 +24,5 @@ def main() -> None:
         server.start_tcp(args.host, args.port)
     else:
         server.start_io()
+
+main()


### PR DESCRIPTION
We can run just `python3 -mrpm_spec_language_server`.