### PR TITLE
Improve logging and remove --tcp option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,16 @@ Running the server
 
 - Install the dependencies via :command:`poetry install`
 - Launch the server in tcp mode (binds to ``127.0.0.1:2087`` by default) via
-  :command:`python3 -mrpm_spec_language_server --tcp`
+  :command:`poetry run rpm_lsp_server`
+
+Alternatively, you can build the python package, install the wheel and run the
+module directly:
+
+.. code-block:: shell-session
+
+   poetry build
+   pip install --user dist/rpm_spec_language_server-*.whl
+   python -m rpm_spec_language_server
 
 
 Clients
@@ -35,8 +44,9 @@ requires nodejs and the :command:`npm` package manager:
 Install the created :file:`rpm-spec-language-server-$VERSION.vsix` and launch
 the language server in tcp mode.
 
-vis with [vis-lspci](https://gitlab.com/muhq/vis-lspc)
-------------------------------------------------------
+
+vis with `vis-lspci <https://gitlab.com/muhq/vis-lspc>`_
+--------------------------------------------------------
 
 Add to your `~/.config/vis/visrc.lua` this code:
 
@@ -47,8 +57,9 @@ Add to your `~/.config/vis/visrc.lua` this code:
     lsp.highlight_diagnostics = true
     lsp.ls_map['rpmspec'] = {
         name = 'RPMSpec',
-        cmd = 'python3 -mrpm_spec_language_server --tcp'
+        cmd = 'python3 -mrpm_spec_language_server'
     }
+
 
 Neovim with built-in LSP client
 -------------------------------
@@ -56,16 +67,15 @@ Neovim with built-in LSP client
 .. code-block:: lua
 
     local nvim_lsp = require('lspconfig')
-    
+
     require('lspconfig.configs').rpmspec = {
         default_config = {
             cmd = {'rpm_lsp_server', '--verbose',
-                   '--log_file', vim.fn.stdpath('state') .. '/rpm_spec_lsp-log.txt',
-                   '--tcp'},
+                   '--log_file', vim.fn.stdpath('state') .. '/rpm_spec_lsp-log.txt'},
             filetypes = {'spec'},
             single_file_support = true,
             settings = {},
         }
     }
-    
+
     nvim_lsp['rpmspec'].setup({})

--- a/rpm_spec_language_server/__main__.py
+++ b/rpm_spec_language_server/__main__.py
@@ -1,3 +1,4 @@
-import rpm_spec_language_server.main as main
+from rpm_spec_language_server.main import main
 
-main.main()
+
+main()

--- a/rpm_spec_language_server/main.py
+++ b/rpm_spec_language_server/main.py
@@ -4,15 +4,26 @@ from rpm_spec_language_server.server import create_rpm_lang_server
 logging.basicConfig(format="%(levelname)s:%(funcName)s:%(message)s", level=logging.INFO)
 log = logging.getLogger()
 
+_LOG_LEVELS = [
+    logging.WARNING,
+    logging.INFO,
+    logging.DEBUG,
+]
+
 
 def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--verbose", action="count", help="Verbose logging")
-    parser.add_argument("--log_file", type=str, help="File to log in")
     parser.add_argument(
-        "--tcp", action="store_true", help="Use TCP server instead of stdio"
+        "-v",
+        "--verbose",
+        action="count",
+        help="Set the logging verbosity, defaults to warning",
+    )
+    parser.add_argument("--log_file", type=str, help="File to log in", nargs=1)
+    parser.add_argument(
+        "--stdout", action="store_true", help="Use stdio instead of the TCP server"
     )
     parser.add_argument(
         "--host", type=str, default="127.0.0.1", help="Bind to this address"
@@ -21,17 +32,17 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    log_level = _LOG_LEVELS[min(args.verbose or 0, len(_LOG_LEVELS) - 1)]
+
     if args.log_file:
-        args.verbose = 1 if args.verbose <= 1 else args.verbose
         log.removeHandler(log.handlers[0])
         log.addHandler(logging.FileHandler(args.log_file))
 
-    if args.verbose > 0:
-        log.setLevel(logging.DEBUG)
+    log.setLevel(log_level)
 
     server = create_rpm_lang_server()
 
-    if args.tcp:
-        server.start_tcp(args.host, args.port)
-    else:
+    if args.stdout:
         server.start_io()
+    else:
+        server.start_tcp(args.host, args.port)


### PR DESCRIPTION
- the verbosity setting was a binary switch, now you can use it to toggle between warning, info and debug levels
- the `--tcp` switch makes no sense, it should be the default => introduce the `--stdout` flag instead to use stdout
- the `__main__` module is pretty empty => merge `main` and `__main__` into one
- update readme to reflect new flags