### PR TITLE
fix: args.log_file is a list not str.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,13 +53,10 @@ Add to your `~/.config/vis/visrc.lua` this code:
 .. code-block:: lua
 
     lsp = require('plugins/vis-lspc')
-    lsp.logging = true
-    lsp.highlight_diagnostics = true
     lsp.ls_map['rpmspec'] = {
         name = 'RPMSpec',
-        cmd = 'python3 -mrpm_spec_language_server'
+        cmd = 'python3 -mrpm_spec_language_server --stdio'
     }
-
 
 Neovim with built-in LSP client
 -------------------------------
@@ -70,12 +67,19 @@ Neovim with built-in LSP client
 
     require('lspconfig.configs').rpmspec = {
         default_config = {
-            cmd = {'rpm_lsp_server', '--verbose',
-                   '--log_file', vim.fn.stdpath('state') .. '/rpm_spec_lsp-log.txt'},
-            filetypes = {'spec'},
-            single_file_support = true,
-            settings = {},
-        }
+          cmd = { 'python3', '-mrpm_lsp_server', '--stdio' },
+          filetypes = { 'spec' },
+          single_file_support = true,
+          root_dir = util.find_git_ancestor,
+          settings = {},
+        },
+        docs = {
+          description = [[
+      https://github.com/dcermak/rpm-spec-language-server
+
+      Language server protocol (LSP) support for RPM Spec files.
+      ]],
+        },
     }
 
     nvim_lsp['rpmspec'].setup({})

--- a/rpm_spec_language_server/main.py
+++ b/rpm_spec_language_server/main.py
@@ -36,7 +36,7 @@ def main() -> None:
 
     if args.log_file:
         log.removeHandler(log.handlers[0])
-        log.addHandler(logging.FileHandler(args.log_file))
+        log.addHandler(logging.FileHandler(args.log_file[0]))
 
     log.setLevel(log_level)
 


### PR DESCRIPTION
> Note that `nargs=1` produces a list of one item. This is
> different from the default, in which the item is produced by
> itself.
> https://docs.python.org/3/library/argparse.html?highlight=add_argument#nargs

I am not sure, whether that `nargs=1` is good for anything, by the way, but I suppose somebody who added it there knew what he was doing.

With this, neovim actually completes `%pyt` to `%pytest` among other many suggestions (we should get some filtering out of obsolete and nonsensical suggestions like `%pypy*` or all `%py3*` macros).