### PR TITLE
macros.py: Use markdown in Hover to highlight macros

### DIFF
--- a/rpm_spec_language_server/server.py
+++ b/rpm_spec_language_server/server.py
@@ -28,6 +28,8 @@ from lsprotocol.types import (
     HoverParams,
     Location,
     LocationLink,
+    MarkupContent,
+    MarkupKind,
     Position,
     Range,
     SymbolInformation,
@@ -417,7 +419,10 @@ def create_rpm_lang_server() -> RpmSpecLanguageServer:
             return Hover(contents="builtin")
 
         try:
-            return Hover(contents=Macros.expand(macro.body))
+            expanded_macro = Macros.expand(macro.body)
+            formatted_macro = f"```bash\n{expanded_macro}\n```"
+            contents = MarkupContent(kind=MarkupKind.Markdown, value=formatted_macro)
+            return Hover(contents)
         except RPMException:
             return Hover(contents=macro.body)
 


### PR DESCRIPTION
By injecting the macro inside a markdown code block, the user can see the expanded macro with syntax highlighting.

Unfortunately having bash or sh code block in my neovim nightly is currently broken, but this should work on other editors.

This PR is not 100% correct, as I guess that we should get the HoverClientCapabilities and check if the client support markdown strings.