### PR TITLE
Correct postgresql package name to not install in Fedora container

### DIFF
--- a/Containerfile.fedora
+++ b/Containerfile.fedora
@@ -5,7 +5,7 @@ RUN set -euo pipefail; \
     dnf -y install findutils poetry python3-pip; \
     # install all packages providing a rpm macro, but filter out all packages with conflicts
     # build-constraints has file level conflicts with redhat-rpm-config
-    dnf rq --whatprovides 'rpm_macro(*)' --qf "%{name}\n" | uniq | sed -e '/postgresql15/d' -e '/release-common/d' -e '/build-constraints/d' | xargs dnf -y install; \
+    dnf rq --whatprovides 'rpm_macro(*)' --qf "%{name}\n" | uniq | sed -e '/postgresql17/d' -e '/release-common/d' -e '/build-constraints/d' | xargs dnf -y install; \
     # install the previously filtered out packages
     dnf -y install fedora-release-common;
 


### PR DESCRIPTION
This breakage was caused by fedora release f42 and bumping the postgresql version